### PR TITLE
API-112 Fix circular reference in JSON.Stringify()

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -38,7 +38,8 @@ module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptio
   const conversionInput = {type: 'json', data: deReferencedOpenApiSchema};
   const conversionOptions = {
     folderStrategy: 'Tags',
-    collapseFolders: false
+    collapseFolders: false,
+    optimizeConversion: false
   };
   const conversion = await convert(conversionInput, conversionOptions);
   if (!conversion.result) {


### PR DESCRIPTION
### Fixed

- Disabled `optimizeConversion` so openapi-to-postmanv2 does not call JSON.Stringify(), which sometimes crashes due to circular references in the dereferenced OpenAPI spec

---

Ticket: https://jira.uitdatabank.be/browse/API-112