### PR TITLE
API-112 Support different auth methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ openapi2postman --help
 ### Usage
 
 ```
-openapi2postman convert <open-api-file> <client-id> <client-secret> [-o <output file>] [-e <environment>] [-b <base URL>] [-g <token grant type>] [--userAuthCallbackUrl <callback url>]
+openapi2postman convert <open-api-file> [-a <auth type>] [-i <client-id>] [-s <client-secret>] [-o <output file>] [-e <environment>] [-b <base URL>] [-g <token grant type>] [--userAuthCallbackUrl <callback url>]
 ```
 
 Required arguments:
 
 -  `open-api-file`: Path or URL to an OpenAPI file
--  `client-id`: Client ID to use for authentication
--  `client-secret`: Client secret to use for authentication
 
 Optional arguments:
 
+- `-a` or `--authMethod`: Authentication method to configure. Can be one of `none`, `token` or `x-client-id`. Defaults to `none`. Note that the supported methods can vary from API to API.
+- `-i` or `--clientId`: Client id to use for authentication (if `--authMethod` is set to `token` or `x-client-id`)
+- `-s` or `--clientSecret`: Client secret to use for authentication (if `--authMethod` is set to `token`)
 - `-o` or `--outputFileName`: File to write the resulting Postman collection to
 - `-e` or `--environment`: Environment to use for authentication and base URL. Can be one of `acc`, `test`, or `prod`. Defaults to `test`.
 - `-b` or `--baseUrl`: Custom base URL to overwrite the one set automatically by the chosen environment (for example for dev environments) or in case there is no base URL defined for the chosen environment or in the OpenAPI file.
@@ -47,10 +48,10 @@ Optional arguments:
 - `--authPerRequest`: Configures the authorization settings per request instead of globally.
 - `-p` or `--prettyPrint`: Includes newlines and indentation (2 spaces) in the output for readability.
 
-#### Example with only required arguments
+#### Basic example
 
 ```
-openapi2postman convert my-open-api-file.json MY_CLIENT_ID MY_CLIENT_SECRET
+openapi2postman convert my-open-api-file.json -a token -i MY_CLIENT_ID -s MY_CLIENT_SECRET
 ```
 
 This will create a Postman collection based on the given OpenAPI file `my-open-api-file.json`.
@@ -75,12 +76,12 @@ Instead of using a local OpenAPI file, you can also use a URL that points to an 
 
 UiTdatabank Entry API:
 ```
-openapi2postman convert 'https://stoplight.io/api/v1/projects/publiq/uitdatabank/nodes/reference/entry.json?deref=optimizedBundle' MY_CLIENT_ID MY_CLIENT_SECRET -o uitdatabank.entry.postman.json
+openapi2postman convert 'https://stoplight.io/api/v1/projects/publiq/uitdatabank/nodes/reference/entry.json?deref=optimizedBundle' -a token -i MY_CLIENT_ID -s MY_CLIENT_SECRET -o uitdatabank.entry.postman.json
 ```
 
 UiTPAS API:
 ```
-openapi2postman convert 'https://stoplight.io/api/v1/projects/publiq/uitpas/nodes/reference/UiTPAS.v2.json?deref=optimizedBundle' MY_CLIENT_ID MY_CLIENT_SECRET -o uitpas.postman.json
+openapi2postman convert 'https://stoplight.io/api/v1/projects/publiq/uitpas/nodes/reference/UiTPAS.v2.json?deref=optimizedBundle' -a token -i MY_CLIENT_ID -s MY_CLIENT_SECRET -o uitpas.postman.json
 ```
 
 (The example URLs above point to the OpenAPI files for the "Stable" branches of the APIs' documentation.)

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,12 +6,20 @@ const fs = require('fs');
 
 const convertWithArgv = (argv) => {
   const {openApiSchemaFile, environment, baseUrl, outputFileName, prettyPrint} = argv;
-  const authOptions = {
-    tokenGrantType: argv.tokenGrantType,
-    clientId: argv.clientId,
-    clientSecret: argv.clientSecret,
-    authPerRequest: argv.authPerRequest
-  };
+  const authOptions = {authMethod: argv.authMethod};
+
+  switch (authOptions.authMethod) {
+    case 'x-client-id':
+      authOptions.clientId = argv.clientId;
+      break;
+
+    case 'token':
+      authOptions.tokenGrantType = argv.tokenGrantType;
+      authOptions.clientId = argv.clientId;
+      authOptions.clientSecret = argv.clientSecret;
+      authOptions.authPerRequest = argv.authPerRequest;
+      break;
+  }
 
   if (authOptions.tokenGrantType === 'authorization_code') {
     const {userAuthCallbackUrl} = argv;
@@ -43,20 +51,31 @@ yargs
   .scriptName("openapi2postman")
   .usage('$0 <cmd> [args]')
   .command(
-    'convert <openApiSchemaFile> <clientId> <clientSecret> [environment] [baseUrl] [tokenGrantType] [userAuthCallbackUrl] [outputFileName] [prettyPrint]',
+    'convert <openApiSchemaFile> [authMethod] [clientId] [clientSecret] [environment] [baseUrl] [tokenGrantType] [userAuthCallbackUrl] [outputFileName] [prettyPrint]',
     'Convert an OpenAPI schema file to a Postman collection and configure it for integrators',
     (yargs) => {
       yargs.positional('openApiSchemaFile', {
         type: 'string',
         describe: 'the OpenAPI file to convert'
       });
-      yargs.positional('clientId', {
-        type: 'string',
-        describe: 'the client\'s id to use for authentication'
+      yargs.option('authMethod', {
+        alias: 'a',
+        default: 'none',
+        choices: ['none', 'token', 'x-client-id'],
+        describe: 'the authentication method to configure (mostly depends on the chosen API)',
+        type: 'string'
       });
-      yargs.positional('clientSecret', {
-        type: 'string',
-        describe: 'the client\'s secret to use for authentication'
+      yargs.option('clientId', {
+        alias: 'i',
+        default: '',
+        describe: 'the client\'s id to use for authentication',
+        type: 'string'
+      });
+      yargs.option('clientSecret', {
+        alias: 's',
+        default: '',
+        describe: 'the client\'s secret to use for authentication',
+        type: 'string'
       });
       yargs.option('environment', {
         alias: 'e',

--- a/convert.js
+++ b/convert.js
@@ -3,7 +3,7 @@ const Converter = require('openapi-to-postmanv2');
 const util = require('util');
 
 module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptions, verbose) => {
-  const { tokenGrantType, clientId, clientSecret, callbackUrl, authPerRequest = false } = authOptions;
+  const { authMethod, tokenGrantType, clientId, clientSecret, callbackUrl, authPerRequest = false } = authOptions;
   const environmentSuffix = (environment === 'prod') ? '' : '-' + environment;
   const environmentNameMap = {
     acc: 'Acceptance',
@@ -44,7 +44,7 @@ module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptio
   if (!conversion.result) {
     throw conversion.reason;
   }
-  const postmanCollection = conversion.output[0].data;
+  let postmanCollection = conversion.output[0].data;
   log('Converted OpenAPI schema to Postman v2.1 collection!');
 
   // Remove empty collections on the root level, created due to tags in OpenAPI that have no visible operations.
@@ -80,9 +80,83 @@ module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptio
   };
   postmanCollection.item = postmanCollection.item.map(addRawUrlPropertyToItem);
 
-  // Configure authentication (only user access tokens for now).
-  log('Adding authentication configuration...');
+  if (authMethod !== 'none') {
+    // Configure authentication
+    log('Adding authentication configuration...');
 
+    switch (authMethod) {
+      case 'token':
+        postmanCollection = configureOAuth2(
+          postmanCollection,
+          tokenGrantType,
+          clientId,
+          clientSecret,
+          callbackUrl,
+          'https://account' + environmentSuffix + '.uitid.be'
+        );
+        break;
+
+      case 'x-client-id':
+        postmanCollection = configureClientIdHeader(postmanCollection, clientId);
+        break;
+    }
+
+    // Configure every request to inherit auth from parent (the collection) or use its own auth.
+    const configureItemAuth = (item) => {
+      if (item.request) {
+        item.request.auth = authPerRequest ? postmanCollection.auth : null;
+      }
+      if (item.item) {
+        item.item = item.item.map(configureItemAuth);
+      }
+      return item;
+    };
+    postmanCollection.item = postmanCollection.item.map(configureItemAuth);
+
+    log('Added authentication configuration!');
+  }
+
+  // Configure the base URL for the given environment.
+  log('Configuring base url...');
+  // Remove the baseUrl set by the Postman converter
+  postmanCollection.variable = postmanCollection.variable.filter((variable) => variable.key !== 'baseUrl');
+  let baseUrl = '';
+  if (customBaseUrl.length > 0) {
+    // If a custom base url is given, use that.
+    baseUrl = customBaseUrl;
+    log('Using custom base URL provided with -b/--baseUrl option (' + baseUrl + ')');
+  } else {
+    const servers = deReferencedOpenApiSchema.servers || [];
+    const environmentServer = servers.find((server) => server.description === environmentName);
+    const testServer = servers.find((server) => server.description === environmentNameMap.test);
+    if (environmentServer) {
+      // If a server is found for the given environment in the OpenAPI file, use that server's URL.
+      baseUrl = environmentServer.url;
+      log('Using base URL defined for ' + environmentName + ' server in the OpenAPI file.');
+    } else if (environment === 'acc' && testServer) {
+      // Otherwise use the test server's URL (if found) and replace the `-test.` suffix with `-acc.`.
+      baseUrl = testServer.url.replace('-test.', '-acc.');
+      warn(
+        'Warning: No base URL defined for ' + environmentName + ' server in the OpenAPI file. ' +
+        'Guessed the base URL based on the base URL for the ' + environmentNameMap.test + ' environment.'
+      );
+    }
+  }
+  postmanCollection.variable.push({
+    key: 'baseUrl',
+    value: baseUrl
+  });
+  if (baseUrl.length > 0) {
+    log('Configured base url!');
+  } else {
+    warn('Could not configure base URL, no server found in OpenAPI schema for ' + environmentName + ' environment.');
+    warn('Make sure to configure the correct base URL yourself after importing the Postman collection!');
+  }
+
+  return postmanCollection;
+}
+
+const configureOAuth2 = (postmanCollection, tokenGrantType, clientId, clientSecret, callbackUrl, authServerUrl) => {
   postmanCollection.auth = {
     type: "oauth2",
     oauth2: [
@@ -162,14 +236,14 @@ module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptio
     },
     {
       key: 'oauth2AccessTokenUrl',
-      value: 'https://account' + environmentSuffix + '.uitid.be/oauth/token'
+      value: authServerUrl + '/oauth/token'
     },
   ];
   if (tokenGrantType === 'authorization_code') {
     postmanCollection.variable = postmanCollection.variable.concat([
       {
         key: 'oauth2AuthUrl',
-        value: 'https://account' + environmentSuffix + '.uitid.be/authorize?audience=https://api.publiq.be&prompt=login'
+        value: authServerUrl + '/authorize?audience=https://api.publiq.be&prompt=login'
       },
       {
         key: 'oauth2RedirectUri',
@@ -178,56 +252,33 @@ module.exports = async (openApiSchemaFile, environment, customBaseUrl, authOptio
     ]);
   }
 
-  // Configure every request to inherit auth from parent (the collection) or use its own auth.
-  const configureItemAuth = (item) => {
-    if (item.request) {
-      item.request.auth = authPerRequest ? postmanCollection.auth : null;
-    }
-    if (item.item) {
-      item.item = item.item.map(configureItemAuth);
-    }
-    return item;
+  return postmanCollection;
+};
+
+const configureClientIdHeader = (postmanCollection, clientId) => {
+  postmanCollection.auth = {
+    type: 'apikey',
+    apikey: [
+      {
+        "key": "value",
+        "value": "{{clientId}}",
+        "type": "string"
+      },
+      {
+        "key": "key",
+        "value": "x-client-id",
+        "type": "string"
+      }
+    ]
   };
-  postmanCollection.item = postmanCollection.item.map(configureItemAuth);
 
-  log('Added authentication configuration!');
-
-  // Configure the base URL for the given environment.
-  log('Configuring base url...');
-  // Remove the baseUrl set by the Postman converter
-  postmanCollection.variable = postmanCollection.variable.filter((variable) => variable.key !== 'baseUrl');
-  let baseUrl = '';
-  if (customBaseUrl.length > 0) {
-    // If a custom base url is given, use that.
-    baseUrl = customBaseUrl;
-    log('Using custom base URL provided with -b/--baseUrl option (' + baseUrl + ')');
-  } else {
-    const servers = deReferencedOpenApiSchema.servers || [];
-    const environmentServer = servers.find((server) => server.description === environmentName);
-    const testServer = servers.find((server) => server.description === environmentNameMap.test);
-    if (environmentServer) {
-      // If a server is found for the given environment in the OpenAPI file, use that server's URL.
-      baseUrl = environmentServer.url;
-      log('Using base URL defined for ' + environmentName + ' server in the OpenAPI file.');
-    } else if (environment === 'acc' && testServer) {
-      // Otherwise use the test server's URL (if found) and replace the `-test.` suffix with `-acc.`.
-      baseUrl = testServer.url.replace('-test.', '-acc.');
-      warn(
-        'Warning: No base URL defined for ' + environmentName + ' server in the OpenAPI file. ' +
-        'Guessed the base URL based on the base URL for the ' + environmentNameMap.test + ' environment.'
-      );
+  // Set authentication variables
+  postmanCollection.variable = [
+    {
+      key: 'clientId',
+      value: clientId
     }
-  }
-  postmanCollection.variable.push({
-    key: 'baseUrl',
-    value: baseUrl
-  });
-  if (baseUrl.length > 0) {
-    log('Configured base url!');
-  } else {
-    warn('Could not configure base URL, no server found in OpenAPI schema for ' + environmentName + ' environment.');
-    warn('Make sure to configure the correct base URL yourself after importing the Postman collection!');
-  }
+  ];
 
   return postmanCollection;
 }


### PR DESCRIPTION
### Added

- Added support for different auth methods (`none`, `token`, and `x-client-id`), as some APIs don't have any auth (Taxonomy API) or use client identification instead of tokens (Search API)

---

Ticket: https://jira.uitdatabank.be/browse/API-112